### PR TITLE
Implement easter eggs and copy helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,15 +246,43 @@
         width: 100%;
         opacity: 1;
       }
-      
+
       .blinking-cursor::after {
         animation: none;
       }
     }
+
+
+    .flash {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      background: #333;
+      color: #fff;
+      padding: 0.25rem 0.5rem;
+      border-radius: 4px;
+      transition: opacity 0.2s;
+    }
+
+    .opacity-0 {
+      opacity: 0;
+      pointer-events: none;
+    }
+    .copy-all { background:#444; color:#fff; border:1px solid #666; margin-left:0.5rem; padding:0 0.5rem; cursor:pointer; }
+
+
+    body.high-contrast {
+      background: #000 !important;
+      color: #FFF !important;
+    }
+
+    body.high-contrast .terminal-container {
+      border-color: #FFF;
+    }
   </style>
 </head>
 <body>
-  <div class="terminal-container">
+  <div id="terminal" class="terminal-container">
     <div id="outputArea" class="terminal-output" role="log" aria-live="polite" aria-label="Terminal output">
       <p class="typing-effect-line success">Welcome to SitemapScanner v2.0</p>
       <p class="typing-effect-line" style="animation-delay: 0.2s;">Type 'help' for commands.</p>
@@ -277,8 +305,10 @@
         aria-label="Command input"
         placeholder="Enter command or URL..."
       />
+        <button id="copyAllBtn" class="copy-all" aria-label="Copy URLs">copy</button>
     </div>
   </div>
+  <div id="flash" class="flash opacity-0" aria-live="polite"></div>
   <script>
     (function() {
       'use strict';
@@ -286,8 +316,29 @@
       let state = {
         currentAnimationDelay: 0.4,
         crawlHistory: [],
-        isProcessing: false
+        isProcessing: false,
+        currentUrls: []
       };
+
+      const fortunes = [
+        'Build fast, break nothing.',
+        'Less code, more clarity.',
+        'Automate the boring stuff.'
+      ];
+
+      const konamiSeq = [
+        'ArrowUp',
+        'ArrowUp',
+        'ArrowDown',
+        'ArrowDown',
+        'ArrowLeft',
+        'ArrowRight',
+        'ArrowLeft',
+        'ArrowRight',
+        'b',
+        'a'
+      ];
+      let konamiStep = 0;
 
       function escapeHtml(text) {
         const div = document.createElement('div');
@@ -341,32 +392,44 @@
         }
       }
 
-      function addLine(text, className = '') {
+      function addLine(text, className = '', child) {
         const outputArea = document.getElementById('outputArea');
         const line = document.createElement('p');
-        
+
         line.className = 'typing-effect-line' + (className ? ' ' + className : '');
-        line.textContent = text;
-        line.style.animationDelay = `${state.currentAnimationDelay}s`;
-        
-        if (text.length > 80) {
+        if (child) {
+          line.appendChild(child);
+        } else {
+          line.textContent = text;
+        }
+        line.style.animationDelay = "0.02s";
+
+        const len = child ? child.textContent.length : text.length;
+        if (len > 80) {
           line.classList.add('full-width');
         }
-        
+
         outputArea.appendChild(line);
-        state.currentAnimationDelay += 0.03;
-        
+
         setTimeout(() => {
           outputArea.scrollTop = outputArea.scrollHeight;
-        }, state.currentAnimationDelay * 1000);
-
+        }, 20);
         return line;
+      }
+
+
+      function flash(text) {
+        const box = document.getElementById('flash');
+        box.textContent = text;
+        box.classList.remove('opacity-0');
+        setTimeout(() => box.classList.add('opacity-0'), 800);
       }
 
       function clearOutput() {
         const outputArea = document.getElementById('outputArea');
         outputArea.innerHTML = '';
         state.currentAnimationDelay = 0;
+        state.currentUrls = [];
         addLine('Welcome to SitemapScanner v2.0', 'success');
         addLine('Type \'help\' for commands.');
       }
@@ -408,6 +471,15 @@
         addLine(`Browser: ${navigator.userAgent.split(' ')[0]}`);
       }
 
+      function showFortune() {
+        const msg = fortunes[Math.floor(Math.random() * fortunes.length)];
+        addLine(msg, 'success');
+      }
+
+      function showUptime() {
+        addLine('up 10 years, fan RPM 9001', 'success');
+      }
+
       async function fetchSitemap(url) {
         const response = await fetch(`./get_sitemap.php?url=${encodeURIComponent(url)}`);
         const data = await response.json();
@@ -444,9 +516,34 @@
           showHistory();
           return;
         }
-        
+
         if (command === 'status') {
           showStatus();
+          return;
+        }
+
+        if (command === 'fortune') {
+          showFortune();
+          return;
+        }
+
+        if (command === 'uptime') {
+          showUptime();
+          return;
+        }
+
+        if (command.startsWith('copy ')) {
+          const idx = parseInt(command.split(' ')[1], 10);
+          if (!idx) {
+            addLine('Missing index; use copy <n>', 'error');
+            return;
+          }
+          const entry = state.crawlHistory[idx - 1];
+          if (!entry) {
+            addLine('Index not found in history.', 'error');
+            return;
+          }
+          navigator.clipboard.writeText(entry.url).then(() => addLine('\u2611 copied'));
           return;
         }
         
@@ -464,6 +561,7 @@
           
           const uniqueUrls = [...new Set(urls)].sort();
           
+          state.currentUrls = uniqueUrls;
           addLine('');
           addLine(`Found ${uniqueUrls.length} unique URLs:`, 'success');
           addLine('');
@@ -473,7 +571,7 @@
           } else {
             const displayUrls = uniqueUrls.slice(0, 1000);
             displayUrls.forEach(url => {
-              addLine(url, 'url-item');
+              addLine(url);
             });
             
             if (uniqueUrls.length > 1000) {
@@ -489,6 +587,7 @@
           addLine(`Error: ${error.message}`, 'error');
           logActivity('scan', input, error.message);
         } finally {
+          state.currentUrls = [];
           state.isProcessing = false;
         }
       }
@@ -500,21 +599,50 @@
           if (e.key === 'Enter') {
             const command = input.value;
             input.value = '';
-            
+
             if (command.trim()) {
               processCommand(command);
             }
           }
-          
+
           if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
             e.preventDefault();
           }
         });
-        
-        document.addEventListener('click', function() {
-          input.focus();
+
+        const term = document.getElementById('terminal');
+        let selecting = false;
+
+        term.addEventListener('pointerdown', () => selecting = true);
+        window.addEventListener('pointerup', () => selecting = false);
+
+        setInterval(() => {
+          if (!selecting && document.activeElement !== input) input.focus();
+        }, 300);
+        const copyBtn = document.getElementById("copyAllBtn");
+        copyBtn.addEventListener("click", () => {
+          const list = state.currentUrls || [];
+          if (!list.length) {
+            flash("no urls");
+            return;
+          }
+          navigator.clipboard.writeText(list.join("\n")).then(() => flash("copied"));
         });
-        
+
+        window.addEventListener('keydown', function(e) {
+          if (e.key === konamiSeq[konamiStep]) {
+            konamiStep += 1;
+            if (konamiStep === konamiSeq.length) {
+              konamiStep = 0;
+              addLine('FUNKPD DEV MODE ENABLED', 'success');
+              document.body.classList.add('high-contrast');
+              setTimeout(() => document.body.classList.remove('high-contrast'), 5000);
+            }
+          } else {
+            konamiStep = 0;
+          }
+        });
+
         input.focus();
       });
       


### PR DESCRIPTION
## Summary
- add copy-all button and constant typing delay
- store scanned URLs for clipboard export
- stop refocus while selecting and use pointer events
- remove per-link copy buttons

## Testing
- `php -l get_sitemap.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840665d5d9483259a657538e6937f47